### PR TITLE
CMakeLists: Use target_sources instead of a variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 unset(KABUFUDA_INCLUDE_DIR CACHE)
 #set(KABUFUDA_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include CACHE PATH "kabufuda include path" FORCE)
 
-unset(PLAT_SRCS)
-if(WIN32)
-list(APPEND PLAT_SRCS include/kabufuda/winsupport.hpp lib/kabufuda/AsyncIOWin32.cpp)
-else()
-list(APPEND PLAT_SRCS lib/kabufuda/AsyncIOPosix.cpp)
-endif()
-
 add_library(kabufuda STATIC
     include/kabufuda/Constants.hpp
     include/kabufuda/AsyncIO.hpp
@@ -24,7 +17,19 @@ add_library(kabufuda STATIC
     include/kabufuda/Util.hpp lib/kabufuda/Util.cpp
     include/kabufuda/SRAM.hpp lib/kabufuda/SRAM.cpp
     include/kabufuda/WideStringConvert.hpp lib/kabufuda/WideStringConvert.cpp
-    ${PLAT_SRCS})
+)
+
+if(WIN32)
+  target_sources(kabufuda PRIVATE
+    include/kabufuda/winsupport.hpp
+    lib/kabufuda/AsyncIOWin32.cpp
+  )
+else()
+  target_sources(kabufuda PRIVATE
+    lib/kabufuda/AsyncIOPosix.cpp
+  )
+endif()
+
 target_include_directories(kabufuda PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 add_subdirectory(test)


### PR DESCRIPTION
Gets rid of the need to unset the PLAT_SRCS variable. We can just conditionally append the source files to the existing set of sources within the target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/kabufuda/3)
<!-- Reviewable:end -->
