### PR TITLE
CMakeLists: Enable extra standards conformance flags on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,25 @@ add_library(kabufuda STATIC
 )
 
 if(WIN32)
+  if (MSVC)
+    target_compile_options(kabufuda PRIVATE
+      # Enforce various standards compliant behavior.
+      /permissive-
+
+      # Enable standard volatile semantics.
+      /volatile:iso
+
+      # Reports the proper value for the __cplusplus preprocessor macro.
+      /Zc:__cplusplus
+
+      # Allow constexpr variables to have explicit external linkage.
+      /Zc:externConstexpr
+
+      # Assume that new throws exceptions, allowing better code generation.
+      /Zc:throwingNew
+    )
+  endif()
+
   target_sources(kabufuda PRIVATE
     include/kabufuda/winsupport.hpp
     lib/kabufuda/AsyncIOWin32.cpp


### PR DESCRIPTION
These flags are off by default. We can enable these to enforce more standards-compliant behavior.

Given this project is quite small, this is trivial to append.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/kabufuda/6)
<!-- Reviewable:end -->
